### PR TITLE
Add support for the XXX comment prefix

### DIFF
--- a/Scripts/configuration.js
+++ b/Scripts/configuration.js
@@ -26,7 +26,8 @@ exports.Configuration = class Configuration {
     return [
       'broken', 'bug', 'debug', 'deprecated', 'example', 'error',
       'err', 'fail', 'fatal', 'fix', 'hack', 'idea', 'info', 'note', 'optimize', 'question',
-      'refactor', 'remove', 'review', 'task', 'trace', 'update', 'upstream', 'warn', 'warning'
+      'refactor', 'remove', 'review', 'task', 'trace', 'update', 'upstream', 'warn', 'warning',
+      'xxx'
     ]
   }
 

--- a/extension.json
+++ b/extension.json
@@ -199,6 +199,12 @@
           "title": "WARNING",
           "type": "boolean",
           "default": false
+        },
+        {
+          "key": "todo.global-tag-xxx",
+          "title": "XXX",
+          "type": "boolean",
+          "default": false
         }
       ]
     },
@@ -417,6 +423,12 @@
         {
           "key": "todo.workspace-tag-warning",
           "title": "WARNING",
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "key": "todo.workspace-tag-xxx",
+          "title": "XXX",
           "type": "boolean",
           "default": false
         }


### PR DESCRIPTION
Using `XXX` as a tag has a [long history in Unix](https://www.snellman.net/blog/archive/2017-04-17-xxx-fixme/) and is used in Java code to [flag code that's bad even though it works](https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html#395). It's listed as an [example tag on Wikipedia](https://en.wikipedia.org/wiki/Comment_%28computer_programming%29#Tags). I also happen to work on a codebase that uses it as a `FIXME` tag, so I have my own reasons for wanting to see it in my Nova sidebar 😉
